### PR TITLE
Improve profile selection and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.111.0
 uvicorn==0.30.1
-pydantic==1.10.15
+pydantic==1.10.22
 requests==2.32.3
 simplekml==1.3.6

--- a/static/index.html
+++ b/static/index.html
@@ -38,6 +38,7 @@
 <script>
 async function loadProfiles() {
   const sel = document.getElementById('profile');
+  const previous = sel.value;
   sel.innerHTML = '';
   try {
     const res = await fetch('/services');
@@ -54,6 +55,8 @@ async function loadProfiles() {
       opt.textContent = k;
       sel.appendChild(opt);
     }
+    const toSelect = (previous && keys.includes(previous)) ? previous : keys[0];
+    sel.value = toSelect;
   } catch (e) {
     sel.innerHTML = '<option value="">(failed to load profiles)</option>';
   }
@@ -70,7 +73,10 @@ async function exportKmz() {
   }
   const lotplans = lotplansText.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
 
-  const payload = { service_profile: profile, lotplans };
+  const payload = { lotplans };
+  if (profile) {
+    payload.service_profile = profile;
+  }
   try {
     const res = await fetch('/export_kmz', {
       method: 'POST',


### PR DESCRIPTION
### **User description**
## Summary
- allow the export endpoint to fall back to the lone profile when no name is provided and surface an error when multiple are available
- make the UI auto-select the first profile returned from /services and only send a service_profile when present
- upgrade pydantic to 1.10.22 so the app boots cleanly on Python 3.12/Render images

## Testing
- uvicorn app.main:app --reload --port 8000 (with ARCGIS_SERVICES_FILE pointing at a local stub for exercising the flow)
- curl -s http://127.0.0.1:8000/health
- curl -s http://127.0.0.1:8000/services
- curl -s -o /workspace/propertyreport-/test_export.kmz -w "%{http_code}" -H "Content-Type: application/json" -d '{"service_profile":"qld_cadastre_all","lotplans":["3RP67254"]}' http://127.0.0.1:8000/export_kmz
- unzip -p test_export.kmz doc.kml | sed -n '8,40p'

------
https://chatgpt.com/codex/tasks/task_e_68caa30159e883279a8504fd07516d03


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Make service profile optional with fallback logic

- Auto-select first profile in UI dropdown

- Upgrade pydantic for Python 3.12 compatibility

- Improve error handling for profile selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UI Profile Selection"] --> B["Optional Profile Parameter"]
  B --> C["Fallback Logic"]
  C --> D["Single Profile Auto-Select"]
  C --> E["Multiple Profiles Error"]
  F["Pydantic Upgrade"] --> G["Python 3.12 Support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add profile fallback and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main.py

<ul><li>Made <code>service_profile</code> parameter optional in ExportRequest model<br> <li> Added fallback logic to auto-select single profile when none specified<br> <li> Enhanced error handling for profile selection scenarios<br> <li> Removed unused <code>get_profile</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/propertyreport-/pull/1/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+12/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Improve UI profile selection behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

static/index.html

<ul><li>Auto-select first profile in dropdown on load<br> <li> Preserve previous selection when reloading profiles<br> <li> Only send <code>service_profile</code> in payload when present</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/propertyreport-/pull/1/files#diff-3e8602c86d6cf04a5c74b954f9f957b652617102cf8f4b647fe46989f480861d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Update pydantic version for compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

- Upgraded pydantic from 1.10.15 to 1.10.22


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/propertyreport-/pull/1/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

